### PR TITLE
remove resultPath, only use outputDirectory

### DIFF
--- a/core/src/main/java/fr/inria/diversify/runner/InputConfiguration.java
+++ b/core/src/main/java/fr/inria/diversify/runner/InputConfiguration.java
@@ -173,14 +173,11 @@ public class InputConfiguration {
     }
 
     /**
-     * Returns the results path
-     * <p>
-     * NOTE: Possible duplicate of getOutputDirectory
-     *
+     * Returns the output path
      * @return
      */
-    public String getResultPath() {
-        return prop.getProperty("result", prop.getProperty("outputDirectory", ""));
+    public String getOutputDirectory() {
+        return prop.getProperty("outputDirectory", "output");
     }
 
     /**
@@ -242,13 +239,11 @@ public class InputConfiguration {
         //Indicates if the Diversify must report early
         prop.setProperty("early.report", "0");
 
-        //tempory directory
+        //temporary directory
         prop.setProperty("tmpDir", "tmpDir");
 
-        //directory for output (ex sosie)
+        //directory for output
         prop.setProperty("outputDirectory", "output");
-        //directory for output result (ex sosie)
-        prop.setProperty("result", "output_diversify");
 
         prop.setProperty("sosieOnMultiProject", "false");
         prop.setProperty("timeOut", "-1");
@@ -291,7 +286,7 @@ public class InputConfiguration {
      */
     public boolean validate() {
         checkPath("Project path", getProjectPath(), true);
-        checkPath("Source path", getProjectPath() + "/"+ getResultPath() , true);
+        checkPath("Source path", getProjectPath() + "/"+ getOutputDirectory() , true);
         checkPath("Previous transformation path", getPreviousTransformationPath(), false);
         checkPath("Coverage dir", getCoverageDir(), false);
         checkPath("Root dir", getRootPath(), false);

--- a/generator/src/main/java/fr/inria/diversify/CorrectedTransformationsToSosie.java
+++ b/generator/src/main/java/fr/inria/diversify/CorrectedTransformationsToSosie.java
@@ -62,9 +62,9 @@ public class CorrectedTransformationsToSosie {
 
         //Path for resulting files of sosies and non-sosies
 
-        String transfPath = inputConfiguration.getResultPath() + "/coll-minus_sosies.json";
+        String transfPath = inputConfiguration.getOutputDirectory() + "/coll-minus_sosies.json";
 
-        String sosiePath = inputConfiguration.getResultPath() + System.currentTimeMillis() + ".sosies.json" ;
+        String sosiePath = inputConfiguration.getOutputDirectory() + System.currentTimeMillis() + ".sosies.json" ;
 
         sosies = new ArrayList<>();
 

--- a/generator/src/main/java/fr/inria/diversify/FromISSTAToTestEyeFormat.java
+++ b/generator/src/main/java/fr/inria/diversify/FromISSTAToTestEyeFormat.java
@@ -43,7 +43,7 @@ public class FromISSTAToTestEyeFormat {
         Collection<Transformation> r = loadWithSosiesInput(inputConfiguration);
 
         //Save the corrected(*) sosies
-        JsonSosiesOutput sosiesOutput = new JsonSosiesOutput(r, inputConfiguration.getResultPath() + ".corrected.json",
+        JsonSosiesOutput sosiesOutput = new JsonSosiesOutput(r, inputConfiguration.getOutputDirectory() + ".corrected.json",
                 inputConfiguration.getProjectPath() + "/pom.xml", InputConfiguration.LATEST_GENERATOR_VERSION);
         sosiesOutput.write();
 
@@ -71,7 +71,7 @@ public class FromISSTAToTestEyeFormat {
         Log.info("Process code fragment Time: " + Math.abs(System.currentTimeMillis() - t));
 
         t = System.currentTimeMillis();
-        JsonSosiesInput input = new JsonSosiesInput(inputConfiguration.getResultPath(), p);
+        JsonSosiesInput input = new JsonSosiesInput(inputConfiguration.getOutputDirectory(), p);
         Collection<Transformation> r = input.read();
         Log.info("Read Time: " + Math.abs(System.currentTimeMillis() - t));
         return r;
@@ -119,7 +119,7 @@ public class FromISSTAToTestEyeFormat {
             }
         }
 
-        FileWriter fw = new FileWriter(inputConfiguration.getResultPath());
+        FileWriter fw = new FileWriter(inputConfiguration.getOutputDirectory());
         result.write(fw);
         fw.close();
 


### PR DESCRIPTION
I propose to remove the resultPath properties, which duplicate the outputDirectory properties.

IHMO, outputDirectory is better to express to purpose and easier to understand for users.