### PR TITLE
add maven plugin for auto deployment of sosiefier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
     <properties>
         <org.springframework.version>3.0.5.RELEASE</org.springframework.version>
         <android.tools.version>23.1.3</android.tools.version>
+        <github.global.server>github</github.global.server>
     </properties>
 
 
@@ -49,8 +50,51 @@
         </dependency>
     </dependencies>
 
+    <distributionManagement>
+        <repository>
+            <id>internal.repo</id>
+            <name>Temporary Staging Repository</name>
+            <url>file://${project.build.directory}/mvn-repo</url>
+        </repository>
+    </distributionManagement>
+
     <build>
         <plugins>
+
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.1</version>
+                <configuration>
+                    <altDeploymentRepository>internal.repo::default::file://${project.build.directory}/master</altDeploymentRepository>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>com.github.github</groupId>
+                <artifactId>site-maven-plugin</artifactId>
+                <version>0.11</version>
+                <configuration>
+                    <path>${project.distributionManagement.site.url}</path>
+                    <merge>true</merge>
+                    <message>Maven artifacts for ${project.version}</message>  <!-- git commit message -->
+                    <outputDirectory>${project.build.directory}/master</outputDirectory> <!-- matches distribution management repository url above -->
+                    <branch>refs/heads/master</branch>                       <!-- remote branch name -->
+                    <includes><include>**/*</include></includes>
+                    <excludes><exclude>**/*jar-with-dependencies.jar</exclude></excludes>
+                    <repositoryName>stamp-maven-repository</repositoryName>      <!-- github repo name -->
+                    <repositoryOwner>STAMP-project</repositoryOwner>    <!-- github username  -->
+                </configuration>
+                <executions>
+                    <!-- run site-maven-plugin's 'site' target as part of the build's normal 'deploy' phase -->
+                    <execution>
+                        <goals>
+                            <goal>site</goal>
+                        </goals>
+                        <phase>deploy</phase>
+                    </execution>
+                </executions>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
Hello, 

I propose the following changes to be able to deploy sosiefier on a [github repositories](https://github.com/STAMP-project/stamp-maven-repository).

in order to deploy it, add the following lines in your setting.xml of your installed maven:
>  <server>
>       <id>github</id>
>       <username>USERNAME</username>
>       <password>PASSWORD<password>
> </server>

Ensure that the `setting.xml` file is not readable for the world. (`chmod 700 setting.xml`)

and then run

`mvn clean deploy`

